### PR TITLE
Airline: replace CursorLine color by StatusLineNC

### DIFF
--- a/autoload/airline/themes/gruvbox.vim
+++ b/autoload/airline/themes/gruvbox.vim
@@ -18,7 +18,7 @@ function! airline#themes#gruvbox#refresh()
 
   let s:N1 = airline#themes#get_highlight2(['Normal', 'bg'], ['StatusLineNC', 'bg'])
   let s:N2 = airline#themes#get_highlight2(['StatusLineNC', 'bg'], ['Pmenu', 'bg'])
-  let s:N3 = airline#themes#get_highlight2(['StatusLineNC', 'bg'], ['CursorLine', 'bg'])
+  let s:N3 = airline#themes#get_highlight2(['StatusLineNC', 'bg'], ['StatusLineNC', 'fg'])
   let g:airline#themes#gruvbox#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
   let g:airline#themes#gruvbox#palette.normal_modified = { 'airline_c': modified_group }
   let g:airline#themes#gruvbox#palette.normal.airline_warning = warning_group


### PR DESCRIPTION
I replaced CursorLine by StatusLineNC foreground color so it is possible to disable the background for the cursorline and still be able to have a background on normal mode on airline.
Disabling the background also disabled the middle section of airline for normal mode.
As it is the same color, it shouldn't impact anything.

Here is my use case:
set cursorline
hi cursorline ctermbg=none
hi cursorlinenr ctermfg=yellow ctermbg=None


:robot: **This pull request has been automatically copied from morhetz#259** :robot: