### PR TITLE
Adding mail specific highlighting

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1375,6 +1375,40 @@ hi! link jsonBraces GruvboxFg1
 hi! link jsonString GruvboxFg1
 
 " }}}
+" Mail: {{{
+
+" mail header
+hi! link mailHeader GruvBoxBlue
+hi! link mailHeaderKey GruvBoxBlue
+hi! link mailHeaderEmail GruvBoxBlue
+hi! link mailSubject GruvboxBlue
+
+" mail quoted text 
+hi! link mailQuoted1 GruvBoxAqua
+hi! link mailQuoted2 GruvBoxPurple
+hi! link mailQuoted3 GruvBoxYellow
+hi! link mailQuoted4 GruvBoxGreen
+hi! link mailQuoted5 GruvBoxRed
+hi! link mailQuoted6 GruvBoxOrange
+
+hi! link mailQuotedExp1 GruvBoxAqua
+hi! link mailQuotedExp2 GruvBoxPurple
+hi! link mailQuotedExp3 GruvBoxYellow
+hi! link mailQuotedExp4 GruvBoxGreen
+hi! link mailQuotedExp5 GruvBoxRed
+hi! link mailQuotedExp6 GruvBoxOrange
+
+" I did not discover yet for what this is used
+" hi! link mailVerbatim GruvBoxRed
+
+" mail signature 
+hi! link mailSignature GruvBoxFg 
+
+" mail url and emails 
+hi! link mailURL GruvBoxOrange
+hi! link mailEmail GruvBoxOrange
+
+" }}}
 
 
 " Functions -------------------------------------------------------------------


### PR DESCRIPTION
* Adds highlights for mail files which is useful when editing
  mail in vim in company with mutt.
* The patch adds highlights for the email
	- header
	- quotes
	- signature
	- email
	- links
* It also adds comments with more email related highlight groups
  just in case.

:robot: **This pull request has been automatically copied from morhetz#230** :robot: