### PR TITLE
Add support for vim8 terminal ansi colors

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -295,6 +295,25 @@ if has('nvim')
 
   let g:terminal_color_7 = s:fg4[0]
   let g:terminal_color_15 = s:fg1[0]
+elseif has('terminal')
+  let g:terminal_ansi_colors = [
+    \ s:bg0[0],
+    \ s:gb.neutral_red[0],
+    \ s:gb.neutral_green[0],
+    \ s:gb.neutral_yellow[0],
+    \ s:gb.neutral_blue[0],
+    \ s:gb.neutral_purple[0],
+    \ s:gb.neutral_aqua[0],
+    \ s:fg4[0],
+    \ s:gray[0],
+    \ s:red[0],
+    \ s:green[0],
+    \ s:yellow[0],
+    \ s:blue[0],
+    \ s:purple[0],
+    \ s:aqua[0],
+    \ s:fg1[0]
+    \ ]
 endif
 
 " }}}


### PR DESCRIPTION
Vim8 and neovim have different mechanisms for assigning terminal ansi colors. gruvbox has had the neovim implementation for a long time, but not the vim8 version which was added to vim later on.