### PR TITLE
Add colors for fzf status line

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -911,6 +911,10 @@ let g:fzf_colors = {
       \ 'header':  ['fg', 'GruvboxBg3']
       \ }
 
+call s:HL('Fzf1', s:blue, s:bg1)
+call s:HL('Fzf2', s:orange, s:bg1)
+call s:HL('Fzf3', s:fg4, s:bg1)
+
 " }}}
 " Startify: {{{
 


### PR DESCRIPTION
I saw that the support for the fzf plugin was added in #15. Thanks for the work!

I have noticed that fzf's status line colours are still the default as shown in the screenshot below.

**Current master of gruvbox-community/gruvbox**

Dark (before):
![Screen Shot 2019-07-03 at 21 36 18](https://user-images.githubusercontent.com/34995519/60592282-4440b200-9ddb-11e9-9966-4cc4d22c6743.png)

Light (before):
![Screen Shot 2019-07-03 at 21 50 45](https://user-images.githubusercontent.com/34995519/60592940-a352f680-9ddc-11e9-9b8c-c7f1ab938aef.png)

---

I have tried to follow the colouring of airline + current implementation of fzf colors, and came up with the following.

**With this patch**

Dark (after):
![Screen Shot 2019-07-03 at 21 32 56](https://user-images.githubusercontent.com/34995519/60592271-3db23a80-9ddb-11e9-9053-404a35b90dc8.png)

Light (after):
![Screen Shot 2019-07-03 at 21 34 27](https://user-images.githubusercontent.com/34995519/60592335-633f4400-9ddb-11e9-9f87-d638ed667ed9.png)