### PR TITLE
Change SpecialKey group color

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -591,7 +591,7 @@ if version >= 703
 endif
 
 hi! link NonText GruvboxBg2
-hi! link SpecialKey GruvboxBg2
+hi! link SpecialKey GruvboxFg4
 
 call s:HL('Visual',    s:none,  s:bg3, s:invert_selection)
 hi! link VisualNOS Visual


### PR DESCRIPTION
Make `:digraph`s more readable by increasing the contrast for the
`SpecialKey` group.

fix #106