### PR TITLE
Add highlight for ALE virtual text.

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -957,6 +957,10 @@ hi! link ALEErrorSign GruvboxRedSign
 hi! link ALEWarningSign GruvboxYellowSign
 hi! link ALEInfoSign GruvboxBlueSign
 
+hi! link ALEVirtualTextError GruvboxRed
+hi! link ALEVirtualTextWarning GruvboxYellow
+hi! link ALEVirtualTextInfo GruvboxBlue
+
 " }}}
 " Dirvish: {{{
 


### PR DESCRIPTION
[ALE](https://github.com/dense-analysis/ale) allows using Neovim's virtual text for showing error on a line. With this change, we get proper highlight depending on message type:
Example of error:
![Error](https://i.imgur.com/sMgBJdD.png)

And warning:
![Warning](https://i.imgur.com/V0hEaZa.png)