### PR TITLE
Highlight keywords for vim-javascript

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1164,6 +1164,7 @@ hi! link jsParens GruvboxFg3
 hi! link jsNull GruvboxPurple
 hi! link jsUndefined GruvboxPurple
 hi! link jsClassDefinition GruvboxYellow
+hi! link jsOperatorKeyword GruvboxRed
 
 " }}}
 " TypeScript: {{{


### PR DESCRIPTION
Keywords were not highlighted before this patch.