### PR TITLE
Add highlight support for coc.nvim

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -962,6 +962,24 @@ hi! link ALEVirtualTextWarning GruvboxYellow
 hi! link ALEVirtualTextInfo GruvboxBlue
 
 " }}}
+" Coc: {{{
+
+hi! link CocErrorSign GruvboxRedSign
+hi! link CocWarningSign GruvboxYellowSign
+hi! link CocInfoSign GruvboxBlueSign
+hi! link CocHintSign GruvboxAquaSign
+
+hi! link CocErrorVirtualText GruvboxRed
+hi! link CocWarningVirtualText GruvboxYellow
+hi! link CocInfoVirtualText GruvboxBlue
+hi! link CocHintVirtualText GruvboxAqua
+
+hi! link CocErrorFloat GruvboxRed
+hi! link CocWarningFloat GruvboxYellow
+hi! link CocInfoFloat GruvboxBlue
+hi! link CocHintFloat GruvboxAqua
+
+" }}}
 " Dirvish: {{{
 
 hi! link DirvishPathTail GruvboxAqua


### PR DESCRIPTION
Default highlight of [coc.nvim](https://github.com/neoclide/coc.nvim/blob/561ec92488b961571b38fc2ab3a6a5a12078b683/doc/coc.txt#L1738) diagnostic signs doesn't set background color, which looks ugly with the gray signcolumn. With this patch, we can have a consistent background color for signcolumn.

Without patch:
![image](https://user-images.githubusercontent.com/11895323/69004778-98e06600-0953-11ea-9ff9-9b386172c3fe.png)

With patch
![image](https://user-images.githubusercontent.com/11895323/69004746-39825600-0953-11ea-8d3d-5da842710b49.png)
