### PR TITLE
add support for CocHighlightText in coc.nvim

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -979,6 +979,8 @@ hi! link CocWarningFloat GruvboxYellow
 hi! link CocInfoFloat GruvboxBlue
 hi! link CocHintFloat GruvboxAqua
 
+call s:HL('CocHighlightText', s:none, s:gb.bg2)
+
 " }}}
 " Dirvish: {{{
 


### PR DESCRIPTION
Before: (the highlight can barely be seen)
![Screen Shot 2020-01-20 at 15 08 22](https://user-images.githubusercontent.com/7910929/72711512-c3d97700-3b9b-11ea-9387-337c39d93110.png)

After: the contrast is increased
![Screen Shot 2020-01-20 at 15 09 59](https://user-images.githubusercontent.com/7910929/72711553-d18efc80-3b9b-11ea-9007-846efb1b0f68.png)
