### PR TITLE
Remove gitgutter settings

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -387,15 +387,8 @@ endif
 
 let s:sign_column = s:gb.bg1
 
-if exists('g:gitgutter_override_sign_column_highlight') &&
-      \ g:gitgutter_override_sign_column_highlight == 1
-  let s:sign_column = s:number_column
-else
-  let g:gitgutter_override_sign_column_highlight = 0
-
-  if exists('g:gruvbox_sign_column')
-    let s:sign_column = get(s:gb, g:gruvbox_sign_column)
-  endif
+if exists('g:gruvbox_sign_column')
+  let s:sign_column = get(s:gb, g:gruvbox_sign_column)
 endif
 
 let s:color_column = s:gb.bg1


### PR DESCRIPTION
In airblade/vim-gitgutter@0da302c the variable `g:gitgutter_override_sign_column_highlight` was removed and marked obsolete, with an error message during startup.