### PR TITLE
make lightline error red instead of orange

### DIFF
--- a/autoload/lightline/colorscheme/gruvbox.vim
+++ b/autoload/lightline/colorscheme/gruvbox.vim
@@ -24,6 +24,7 @@ if exists('g:lightline')
   let s:blue   = s:getGruvColor('GruvboxBlue')
   let s:aqua   = s:getGruvColor('GruvboxAqua')
   let s:orange = s:getGruvColor('GruvboxOrange')
+  let s:red = s:getGruvColor('GruvboxRed')
   let s:green = s:getGruvColor('GruvboxGreen')
 
   let s:p = {'normal':{}, 'inactive':{}, 'insert':{}, 'replace':{}, 'visual':{}, 'tabline':{}, 'terminal':{}}
@@ -49,7 +50,7 @@ if exists('g:lightline')
   let s:p.tabline.tabsel = [ [ s:bg0, s:fg4 ] ]
   let s:p.tabline.middle = [ [ s:bg0, s:bg4 ] ]
   let s:p.tabline.right = [ [ s:bg0, s:orange ] ]
-  let s:p.normal.error = [ [ s:bg0, s:orange ] ]
+  let s:p.normal.error = [ [ s:bg0, s:red ] ]
   let s:p.normal.warning = [ [ s:bg0, s:yellow ] ]
 
   let g:lightline#colorscheme#gruvbox#palette = lightline#colorscheme#flatten(s:p)


### PR DESCRIPTION
I think the color `red` is more appropriate for errors instead of `orange` but this is probably a matter of preference.

I don't mind if this is getting merged or not, since I'm overwriting the color via:

```
function s:LightLineOverwriteColors() abort
  let l:palette = lightline#palette()
  let l:palette.normal.error = [ ['#1d2021', '#fb4934', '234', '167'] ]

  call lightline#colorscheme()
endfunction

autocmd VimEnter * call s:LightLineOverwriteColors() 
```