### PR TITLE
Adapt `LspDiagnostics*` highlight groups to latest neovim upstream changes (fixes #147)

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -774,24 +774,20 @@ endif
 " }}}
 " LSP: {{{
 
-hi! link LspDiagnosticsError GruvboxRed
-hi! link LspDiagnosticsErrorSign GruvboxRedSign
-hi! link LspDiagnosticsErrorFloating GruvboxRed
+hi! link LspDiagnosticsDefaultError GruvboxRed
+hi! link LspDiagnosticsSignError GruvboxRedSign
 hi! link LspDiagnosticsUnderlineError GruvboxRedUnderline
 
-hi! link LspDiagnosticsWarning GruvboxYellow
-hi! link LspDiagnosticsWarningSign GruvboxYellowSign
-hi! link LspDiagnosticsWarningFloating GruvboxYellow
+hi! link LspDiagnosticsDefaultWarning GruvboxYellow
+hi! link LspDiagnosticsSignWarning GruvboxYellowSign
 hi! link LspDiagnosticsUnderlineWarning GruvboxYellowUnderline
 
-hi! link LspDiagnosticsInformation GruvboxBlue
-hi! link LspDiagnosticsInformationSign GruvboxBlueSign
-hi! link LspDiagnosticsInformationFloating GruvboxBlue
+hi! link LspDiagnosticsDefaultInformation GruvboxBlue
+hi! link LspDiagnosticsSignInformation GruvboxBlueSign
 hi! link LspDiagnosticsUnderlineInformation GruvboxBlueUnderline
 
-hi! link LspDiagnosticsHint GruvboxAqua
-hi! link LspDiagnosticsHintSign GruvboxAquaSign
-hi! link LspDiagnosticsHintFloating GruvboxAqua
+hi! link LspDiagnosticsDefaultHint GruvboxAqua
+hi! link LspDiagnosticsSignHint GruvboxAquaSign
 hi! link LspDiagnosticsUnderlineHint GruvboxAquaUnderline
 
 " }}}


### PR DESCRIPTION
Hey there!

I adapted the highlight groups based on:

* `:help lsp-highlight-diagnostics`
* Info in diagnostic-nvim: https://github.com/nvim-lua/diagnostic-nvim/issues/73
* The [commit](https://github.com/neovim/neovim/commit/f75be5e9d510d5369c572cf98e78d9480df3b0bb) in neovim (relevant [changes](https://github.com/neovim/neovim/pull/12655/files#diff-fb2b7119cd068ae643697e57d3dc10e758737dc763b97b91e5c17736f17b8da8L850))

I set `LspDiagnosticsDefault*` and removed virtual text and floating highlight groups, because they link to default, AFAIU. Fixes #147.

Would be great if someone could review/test :) Thanks!