### PR TITLE
Use the upstream color semantics for EasyMotion.

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -795,8 +795,10 @@ hi! link LspDiagnosticsUnderlineHint GruvboxAquaUnderline
 " Plugin specific -------------------------------------------------------------
 " EasyMotion: {{{
 
-hi! link EasyMotionTarget GruvboxYellowBold
-hi! link EasyMotionShade Comment
+hi! link EasyMotionTarget GruvboxRedBold
+hi! link EasyMotionTarget2First GruvboxYellowBold
+hi! link EasyMotionTarget2Second GruvboxOrangeBold
+hi! link EasyMotionShade GruvboxGray
 
 " }}}
 " Sneak: {{{


### PR DESCRIPTION
Though the changes made nicely fit into a small PR, they consist of three parts:

* The upstream suggests red highlighting for 1-letter targets, which works IMHO much better than yellow because of the contrast. This PR changes the highlighting to red.
* I expanded the coverage of EasyMotion highlighting to include 2-letter targets. The highlighting falls back to inconsistent with gruvbox default colors otherwise.
* The highlighting group for faded text currently points to the comment group, which contains italic styling. The switch of font is very distracting, so I made this group point to GruvboxGray, which is again similar to what upstream does by default.

If some of these points don't make sense, I will revert that particular change.
