### PR TITLE
Let htmlScriptTag point to htmlTag.

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1102,7 +1102,6 @@ hi! link htmlEndTag GruvboxAquaBold
 hi! link htmlTagName GruvboxBlue
 hi! link htmlArg GruvboxOrange
 
-hi! link htmlScriptTag GruvboxPurple
 hi! link htmlTagN GruvboxFg1
 hi! link htmlSpecialTagName GruvboxBlue
 


### PR DESCRIPTION
The current highlighting for the `<script>` tag is inconsistent not only with the other tags but also with the closing `</script>`.

![screenshot](https://user-images.githubusercontent.com/43315801/116690230-c42d0880-a9c1-11eb-9142-c773d7d29ef2.png)