### PR TITLE
Add highlighting to neovim builtin LSP Code Lens

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -794,6 +794,8 @@ hi! link LspReferenceText GruvboxYellowBold
 hi! link LspReferenceRead GruvboxYellowBold
 hi! link LspReferenceWrite GruvboxOrangeBold
 
+hi! link LspCodeLens GruvboxGray
+
 " }}}
 
 " Plugin specific -------------------------------------------------------------


### PR DESCRIPTION
Text displayed by Neovim's builtin LSP code lens is currently hard to distinguish from regular text. This highlights it with gray.

Before:
<img width="662" alt="Screen Shot 2021-08-18 at 4 06 28 PM" src="https://user-images.githubusercontent.com/9307830/129965478-196de8a1-6280-4759-b414-6a6825a9a7d5.png">

After:
<img width="616" alt="Screen Shot 2021-08-18 at 4 08 40 PM" src="https://user-images.githubusercontent.com/9307830/129965505-7fad6835-2f80-416a-8f30-5924d5157eaf.png">
