### PR TITLE
Use new diagnostics sign name

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -774,21 +774,21 @@ endif
 " }}}
 " LSP: {{{
 
-hi! link LspDiagnosticsDefaultError GruvboxRed
-hi! link LspDiagnosticsSignError GruvboxRedSign
-hi! link LspDiagnosticsUnderlineError GruvboxRedUnderline
+hi! link DiagnosticError GruvboxRed
+hi! link DiagnosticSignError GruvboxRedSign
+hi! link DiagnosticUnderlineError GruvboxRedUnderline
 
-hi! link LspDiagnosticsDefaultWarning GruvboxYellow
-hi! link LspDiagnosticsSignWarning GruvboxYellowSign
-hi! link LspDiagnosticsUnderlineWarning GruvboxYellowUnderline
+hi! link DiagnosticWarn GruvboxYellow
+hi! link DiagnosticSignWarn GruvboxYellowSign
+hi! link DiagnosticUnderlineWarn GruvboxYellowUnderline
 
-hi! link LspDiagnosticsDefaultInformation GruvboxBlue
-hi! link LspDiagnosticsSignInformation GruvboxBlueSign
-hi! link LspDiagnosticsUnderlineInformation GruvboxBlueUnderline
+hi! link DiagnosticInfo GruvboxBlue
+hi! link DiagnosticSignInfo GruvboxBlueSign
+hi! link DiagnosticUnderlineInfo GruvboxBlueUnderline
 
-hi! link LspDiagnosticsDefaultHint GruvboxAqua
-hi! link LspDiagnosticsSignHint GruvboxAquaSign
-hi! link LspDiagnosticsUnderlineHint GruvboxAquaUnderline
+hi! link DiagnosticHint GruvboxAqua
+hi! link DiagnosticSignHint GruvboxAquaSign
+hi! link DiagnosticUnderlineHint GruvboxAquaUnderline
 
 hi! link LspReferenceText GruvboxYellowBold
 hi! link LspReferenceRead GruvboxYellowBold


### PR DESCRIPTION
Due to this refactoring(neovim/neovim#15585), there have been changes in the name of the highlighting of the lsp signs.
With not backward compatibility (https://github.com/neovim/neovim/pull/15683)

Perhaps the most sensible thing to do is to leave this branch unmerged until a new stable version is released or create a new branch for it