### PR TITLE
feat(ruby): Highlight defined? as keyword

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1452,6 +1452,7 @@ hi! link coffeeBracket GruvboxOrange
 
 hi! link rubyStringDelimiter GruvboxGreen
 hi! link rubyInterpolationDelimiter GruvboxAqua
+hi! link rubyDefinedOperator rubyKeyword
 
 " }}}
 " ObjectiveC: {{{


### PR DESCRIPTION
Highlighting `defined?` was the main force that made me open #177. But, I believe it should be handled separately.

See: https://docs.ruby-lang.org/en/3.1/doc/syntax/miscellaneous_rdoc.html#label-defined-3F

---

![image](https://user-images.githubusercontent.com/94782/150060626-f3c049f3-9b24-407a-b0b3-4a6f2c53e784.png)