### PR TITLE
add support for nvim-cmp

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1118,6 +1118,31 @@ hi! link TelescopePromptPrefix GruvboxRed
 hi! link TelescopePrompt TelescopeNormal
 
 " }}}
+" nvim-cmp: {{{
+hi! link CmpItemAbbr GruvboxFg0
+hi! link CmpItemAbbrDeprecated GruvboxFg1
+hi! link CmpItemAbbrMatch GruvboxBlueBold
+hi! link CmpItemAbbrMatchFuzzy GruvboxBlueUnderline
+hi! link CmpItemMenu GruvboxGray
+hi! link CmpItemKindText GruvboxOrange
+hi! link CmpItemKindMethod GruvboxBlue
+hi! link CmpItemKindFunction GruvboxBlue
+hi! link CmpItemKindConstructor GruvboxYellow
+hi! link CmpItemKindField GruvboxBlue
+hi! link CmpItemKindClass GruvboxYellow
+hi! link CmpItemKindInterface GruvboxYellow
+hi! link CmpItemKindModule GruvboxBlue
+hi! link CmpItemKindProperty GruvboxBlue
+hi! link CmpItemKindValue GruvboxOrange
+hi! link CmpItemKindEnum GruvboxYellow
+hi! link CmpItemKindKeyword GruvboxPurple
+hi! link CmpItemKindSnippet GruvboxGreen
+hi! link CmpItemKindFile GruvboxBlue
+hi! link CmpItemKindEnumMember GruvBoxAqua
+hi! link CmpItemKindConstant GruvboxOrange
+hi! link CmpItemKindStruct GruvboxYellow
+hi! link CmpItemKindTypeParameter GruvboxYellow
+"}}}
 
 " Filetype specific -----------------------------------------------------------
 " Diff: {{{


### PR DESCRIPTION
Add hightlight for [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
![Screenshot from 2022-03-27 09-24-44](https://user-images.githubusercontent.com/31539177/160263988-6d69c74b-1884-40be-93b5-40aef55feafd.png)
![Screenshot from 2022-03-27 09-25-10](https://user-images.githubusercontent.com/31539177/160263996-2a305dec-21c0-4668-82a2-4471ab61a722.png)

