### PR TITLE
Define a color for CocSearch.

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -1109,6 +1109,7 @@ hi! link CocDiagnosticsHint GruvboxAqua
 
 hi! link CocSelectedText GruvboxRed
 hi! link CocCodeLens GruvboxGray
+hi! link CocSearch GruvboxAqua
 
 hi! link CocErrorHighlight GruvboxRedUnderline
 hi! link CocWarningHighlight GruvboxOrangeUnderline


### PR DESCRIPTION
This group is used to highlight matching characters in the autocompletion popup. It's cyan by default.