### PR TITLE
Remove unnecessary backgrounds from several highlight groups

### DIFF
--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -568,7 +568,7 @@ call s:HL('GruvboxOrangeUnderline', s:none, s:none, s:undercurl, s:gb.orange)
 " General UI: {{{
 
 " Normal text
-call s:HL('Normal', s:gb.fg1, s:gb.bg0)
+call s:HL('Normal', s:gb.fg1)
 
 " Correct background (see issue #7):
 " --- Problem with changing between dark and light on 256 color terminal
@@ -1047,11 +1047,11 @@ endif
 
 if g:indent_guides_auto_colors == 0
   if g:gruvbox_invert_indent_guides == 0
-    call s:HL('IndentGuidesOdd', s:vim_bg, s:gb.bg2)
-    call s:HL('IndentGuidesEven', s:vim_bg, s:gb.bg1)
+    call s:HL('IndentGuidesOdd', s:gb.bg0, s:gb.bg2)
+    call s:HL('IndentGuidesEven', s:gb.bg0, s:gb.bg1)
   else
-    call s:HL('IndentGuidesOdd', s:vim_bg, s:gb.bg2, s:inverse)
-    call s:HL('IndentGuidesEven', s:vim_bg, s:gb.bg3, s:inverse)
+    call s:HL('IndentGuidesOdd', s:gb.bg0, s:gb.bg2, s:inverse)
+    call s:HL('IndentGuidesEven', s:gb.bg0, s:gb.bg3, s:inverse)
   endif
 endif
 
@@ -1654,14 +1654,14 @@ endif
 
 call s:HL('htmlLink', s:gb.fg4, s:none, s:underline)
 
-call s:HL('htmlBold', s:vim_fg, s:vim_bg, s:bold)
-call s:HL('htmlBoldUnderline', s:vim_fg, s:vim_bg, s:bold . s:underline)
-call s:HL('htmlBoldItalic', s:vim_fg, s:vim_bg, s:bold . s:italic)
-call s:HL('htmlBoldUnderlineItalic', s:vim_fg, s:vim_bg, s:bold . s:underline . s:italic)
+call s:HL('htmlBold', s:vim_fg, s:none, s:bold)
+call s:HL('htmlBoldUnderline', s:vim_fg, s:none, s:bold . s:underline)
+call s:HL('htmlBoldItalic', s:vim_fg, s:none, s:bold . s:italic)
+call s:HL('htmlBoldUnderlineItalic', s:vim_fg, s:none, s:bold . s:underline . s:italic)
 
-call s:HL('htmlUnderline', s:vim_fg, s:vim_bg, s:underline)
-call s:HL('htmlUnderlineItalic', s:vim_fg, s:vim_bg, s:underline . s:italic)
-call s:HL('htmlItalic', s:vim_fg, s:vim_bg, s:italic)
+call s:HL('htmlUnderline', s:vim_fg, s:none, s:underline)
+call s:HL('htmlUnderlineItalic', s:vim_fg, s:none, s:underline . s:italic)
+call s:HL('htmlItalic', s:vim_fg, s:none, s:italic)
 
 " }}}
 " Java: {{{
@@ -2232,7 +2232,7 @@ else
   hi! link dtdTagName Special
 
   hi! link docbkKeyword Tag
-  call s:HL('docbkTitle', s:vim_fg, s:vim_bg, s:bold)
+  call s:HL('docbkTitle', s:vim_fg, s:none, s:bold)
 endif
 
 " }}}


### PR DESCRIPTION
Fixes #140.

Since we now don't set a background colour for `Normal`, we can't use `s:vim_bg` anywhere or we'll get `E420: BG colour unknown`. Mostly it was being used in places it shouldn't anyway, but I'm unsure what the `IndentGuides*` groups are used for so I can't be sure that they still look correct with this change.